### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-update-using-python.yml
+++ b/.github/workflows/auto-update-using-python.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Execute Python Script and Push Changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       # Check out the repository code onto the runner


### PR DESCRIPTION
Potential fix for [https://github.com/Strong-Foundation/thispersondoesnotexist-com/security/code-scanning/1](https://github.com/Strong-Foundation/thispersondoesnotexist-com/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves checking out code, running a Python script, and pushing changes, the `contents: write` permission is necessary. Other permissions should be omitted unless explicitly required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job. In this case, adding it to the `build` job is more precise.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
